### PR TITLE
Fix markdown H1 in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: home
 title: "Welcome to the new OpenRefine site"
 ---
 
-#Welcome!
+# Welcome!
 
 
 OpenRefine (formerly Google Refine) is a powerful tool for working with messy data: 


### PR DESCRIPTION
Since Jekyll (and hence GH pages) switched to using kramdown instead of redcarpet for markdown processing, headers *must* have a space between the last `#` and the header text.