### PR TITLE
added hyperlinks for Google News Initiative

### DIFF
--- a/_posts/2018-06-16-Update.md
+++ b/_posts/2018-06-16-Update.md
@@ -57,7 +57,7 @@ In December 2017, [Google News Initiative](https://newsinitiative.withgoogle.com
 
 The [OpenRefine core team](https://github.com/orgs/OpenRefine/people) is currently managing the funds via a private US company to get off the ground quickly. We know that the private US corporation is not a viable solution in the long term and we are currently under discussion to join [Software Freedom Conservancy](https://sfconservancy.org/).
 
-As we begin to use Software Freedom Conservancy as the parent organization of OpenRefine Foundation, we will clarify and formalize our governance model. In the meanwhile, we welcome anyone feedbacks and comments via our GitHub project or our [user](https://groups.google.com/forum/#!forum/openrefine) and [developer](https://groups.google.com/forum/#!forum/openrefine-dev) mailing lists. If you like to request financing for the development of a feature, the attendance or the organization of an event, please reach out via one of our mailing lists.
+As we begin to use Software Freedom Conservancy as the parent organization of OpenRefine Foundation, we will clarify and formalize our governance model. In the meanwhile, we welcome anyone feedbacks and comments via our GitHub project or our [user](https://groups.google.com/forum/#!forum/openrefine) and [developer](https://groups.google.com/forum/#!forum/openrefine-dev) mailing lists. If you would like to request financing for the development of a feature, the attendance or the organization of an event, please reach out via one of our mailing lists.
 
 You can review our usage of the funds in the following [Finance document.](https://docs.google.com/spreadsheets/d/17hldPOw8W_TGM2DuKWbkFX-rexkQiE5esluZ8buadao/)
 

--- a/_posts/2018-06-16-Update.md
+++ b/_posts/2018-06-16-Update.md
@@ -2,7 +2,7 @@
 
 ### OpenRefine 2.8 and 3.0
 
-OpenRefine 3.0 Beta was [released on May 27](https://github.com/OpenRefine/OpenRefine/releases/tag/3.0-beta). This is the second release with the support of Google News Initiative (see more details below) and includes several major enhancements including: 
+OpenRefine 3.0 Beta was [released on May 27](https://github.com/OpenRefine/OpenRefine/releases/tag/3.0-beta). This is the second release with the support of [Google News Initiative](https://newsinitiative.withgoogle.com/) (see more details below) and includes several major enhancements including: 
 
 * Wikidata extension to reconcile, enrich and push data from/to Wikidata. See the [video tutorial](https://www.wikidata.org/wiki/Wikidata:Tools/OpenRefine/Editing/Tutorials/Video) and [Wikidata documentation](https://www.wikidata.org/wiki/Wikidata:Tools/OpenRefine) (2.8 and 3.0);
 * Support of [Data package](https://frictionlessdata.io/data-packages/) metadata standards to describe and package a collection of data (3.0)
@@ -57,14 +57,14 @@ In December 2017, [Google News Initiative](https://newsinitiative.withgoogle.com
 
 The [OpenRefine core team](https://github.com/orgs/OpenRefine/people) is currently managing the funds via a private US company to get off the ground quickly. We know that the private US corporation is not a viable solution in the long term and we are currently under discussion to join [Software Freedom Conservancy](https://sfconservancy.org/).
 
-As we move with Software Freedom Conservancy, we will clarify and formalize our governance model. In the meanwhile, we welcome anyone feedbacks and comments via our GitHub project or our [user](https://groups.google.com/forum/#!forum/openrefine) and [developer](https://groups.google.com/forum/#!forum/openrefine-dev) mailing lists. If you like to request financing for the development of a feature, the attendance or the organization of an event, please reach out via one of our mailing lists.
+As we begin to use Software Freedom Conservancy as the parent organization of OpenRefine Foundation, we will clarify and formalize our governance model. In the meanwhile, we welcome anyone feedbacks and comments via our GitHub project or our [user](https://groups.google.com/forum/#!forum/openrefine) and [developer](https://groups.google.com/forum/#!forum/openrefine-dev) mailing lists. If you like to request financing for the development of a feature, the attendance or the organization of an event, please reach out via one of our mailing lists.
 
 You can review our usage of the funds in the following [Finance document.](https://docs.google.com/spreadsheets/d/17hldPOw8W_TGM2DuKWbkFX-rexkQiE5esluZ8buadao/)
 
 
 ## OpenRefine road map
 
-With the remaining funds available from Google News Initiative, we plan to address the tight coupling between the front and back end and set up the OpenRefine Foundation for the next phases. The current implementation presents technical barriers for new contributors to engage with the community and limits the attractiveness of OpenRefine for developers. 
+With the remaining funds available from [Google News Initiative](https://newsinitiative.withgoogle.com/), we plan to address the tight coupling between the front and back end and set up the OpenRefine Foundation for the next phases. The current implementation presents technical barriers for new contributors to engage with the community and limits the attractiveness of OpenRefine for developers. 
 
 Currently, all OpenRefine contributors are working on the project on top of their other academics, professional lives, and family commitments. While the Google funds help the core team to free some extra time to support OpenRefine, part-time involvement is not enough to address coming milestones (after all, we're a very small team!). We plan to hire fellow(s) / contractor(s) to work full time for a couple of months with the community and take the lead on the three following items (we will share more information regarding the fellow/contractor positions). 
 


### PR DESCRIPTION
Also rephrased moving into Software Freedom Conservancy, the OpenRefine Foundation for more clarity.