### PR TITLE
Add 'title' to config, to change page titles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,4 +35,5 @@ sidebar_home_link:  true
                                 # set this to the root of the paginate_path
                                 # to enable a separate blog link.
 github:             https://github.com/OpenRefine/openrefine.github.com 
+title: OpenRefine
  #repo:           # repo Address 


### PR DESCRIPTION
It currently defaults to the name of the repository, so you get:

* `openrefine.github.com`
* `Community · openrefine.github.com`
* etc

I have checked that this fixes it on my fork (see https://remram44.github.io/openrefine.github.com/community.html)