### PR TITLE
Website link updates

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -11,13 +11,13 @@ sidebar_link: true
 
   <h2 id="documentation-for-user">Documentation for users</h2>
 <ul>
-   <li><a href="https://github.com/OpenRefine/OpenRefine/wiki/">Official documentation</a></li>
+   <li><a href="https://docs.openrefine.org/">Official documentation</a></li>
   <li><a href="https://github.com/OpenRefine/OpenRefine/wiki/FAQ">FAQ</a></li>
 </ul>
 
 <h2 id="documentation-for-developers">Documentation for developers</h2>
 <ul>
-  <li><a href="https://github.com/OpenRefine/OpenRefine/wiki/Documentation-For-Developers">Wiki for developers</a></li>
+  <li><a href="https://docs.openrefine.org/technical-reference/technical-reference-index">Wiki for developers</a></li>
   <li><a href="https://groups.google.com/forum/?fromgroups#!forum/openrefine-dev">Developer discussion list</a></li>
 </ul>
 

--- a/documentation.md
+++ b/documentation.md
@@ -17,7 +17,8 @@ sidebar_link: true
 
 <h2 id="documentation-for-developers">Documentation for developers</h2>
 <ul>
-  <li><a href="https://docs.openrefine.org/technical-reference/technical-reference-index">Wiki for developers</a></li>
+  <li><a href="https://docs.openrefine.org/technical-reference/technical-reference-index">Information for developers</a></li>
+  <li><a href="https://github.com/OpenRefine/OpenRefine/blob/master/CONTRIBUTING.md">Contributor guidelines</a></li>
   <li><a href="https://groups.google.com/forum/?fromgroups#!forum/openrefine-dev">Developer discussion list</a></li>
 </ul>
 

--- a/download.md
+++ b/download.md
@@ -9,12 +9,12 @@ You will find on this page a list of OpenRefine distributions and extensions ava
  
 ## Official Distribution
 
-Read the [installation instructions](https://github.com/OpenRefine/OpenRefine/wiki/Installation-Instructions)
+Read the [installation instructions](https://docs.openrefine.org/manual/installing).
 
 You can also download all official releases and source from our [GitHub releases page](https://github.com/OpenRefine/OpenRefine/releases/)
 
 ### OpenRefine 3.4.1
-The latest stable release of OpenRefine 3.4.1, released on September 24, 2020. Please [backup your workspace directory](https://github.com/OpenRefine/OpenRefine/wiki/Back-Up-OpenRefine-Data) before installing and report any problems that you encounter. A change log is provided on [the release page](https://github.com/OpenRefine/OpenRefine/releases/tag/3.4.1).
+The latest stable release of OpenRefine 3.4.1, released on September 24, 2020. Please [backup your workspace directory](https://docs.openrefine.org/manual/installing#back-up-your-data) before installing and report any problems that you encounter. A change log is provided on [the release page](https://github.com/OpenRefine/OpenRefine/releases/tag/3.4.1).
 
 + **[Windows kit](https://github.com/OpenRefine/OpenRefine/releases/download/3.4.1/openrefine-win-3.4.1.zip)**, 
 This requires Java to be installed on your computer. Download, unzip, and double-click on _openrefine.exe_ or _refine.bat_ if the former does not work.
@@ -27,7 +27,7 @@ Download, extract, then type _./refine_ to start. This requires Java to be insta
 
 
 ### OpenRefine 3.3
-The stable release of OpenRefine 3.3, released on January 31, 2020. Please [backup your workspace directory](https://github.com/OpenRefine/OpenRefine/wiki/Back-Up-OpenRefine-Data) before installing and report any problems that you encounter. A change log is provided on [the release page](https://github.com/OpenRefine/OpenRefine/releases/tag/3.3).
+The stable release of OpenRefine 3.3, released on January 31, 2020. Please [backup your workspace directory](https://docs.openrefine.org/manual/installing#back-up-your-data) before installing and report any problems that you encounter. A change log is provided on [the release page](https://github.com/OpenRefine/OpenRefine/releases/tag/3.3).
 
 + **[Windows kit](https://github.com/OpenRefine/OpenRefine/releases/download/3.3/openrefine-win-3.3.zip)**, 
 Download, unzip, and double-click on _openrefine.exe_. If you're 


### PR DESCRIPTION
Changing most wiki links to the new docs.

There's a link on the Community page that I wanted to ask about before changing: 
https://github.com/OpenRefine/OpenRefine/blob/master/CONTRIBUTING.md
to 
https://docs.openrefine.org/technical-reference/contributing
