### PR TITLE
adds C# .net core client to download page

### DIFF
--- a/download.md
+++ b/download.md
@@ -101,3 +101,4 @@ You can automate some OpenRefine operations using one of the existing libraries.
 * [php](https://github.com/keboola/openrefine-php-client)
 * [java](https://github.com/dtap-gmbh/refine-java)
 * [bash](https://gist.github.com/felixlohmeier/d76bd27fbc4b8ab6d683822cdf61f81d)
+* [C# - .NET Core](https://github.com/ADelRosarioH/OpenRefine.Net)


### PR DESCRIPTION
Hi!

I recently developed a .NET Core client supporting the latest version of OpenRefine. You can take a look in here: https://github.com/ADelRosarioH/OpenRefine.Net.

I would like it to be in the client libraries section of https://openrefine.org/download.html and that's why I'm creating this PR.

I couldn't find any contributing guides for this repo, If there is one, I can close this PR and submit another according to the guide.

Thank you very much!
