### PR TITLE
Replace mentions of the Google Groups with links to the Discourse forum

### DIFF
--- a/community.md
+++ b/community.md
@@ -10,7 +10,7 @@ sidebar_link: true
   <p>
   OpenRefine's user community is very active. You can engage with it:
   <ul>
-    <li>on <a href="http://groups.google.com/group/openrefine/">the official mailing list</a></li>
+    <li>on <a href="https://forum.openrefine.org">the official forum</a></li>
     <li>on <a href="https://gitter.im/OpenRefine/OpenRefine">Gitter chat</a></li>
     <li>on StackOverflow, with the <a href="https://stackoverflow.com/questions/tagged/openrefine"><code>openrefine</code></a> tag</li>
     <li>on Twitter, with the <a href="https://twitter.com/search?f=tweets&vertical=default&q=OpenRefine%20OR%20%22Open%20Refine%22%20OR%20%23OpenRefine&src=typd">#OpenRefine</a> hashtag</li>
@@ -20,7 +20,7 @@ sidebar_link: true
 
 <p>Interested in helping OpenRefine? There are many ways to do so, such as documenting, translating or fixing bugs. More details are available in our <a href="https://github.com/OpenRefine/OpenRefine/blob/master/CONTRIBUTING.md">contribution guidelines</a>.</p>
 <ul>
-  <li>on <a href="https://groups.google.com/g/openrefine-dev/">dev mailing list</a></li>
+  <li>in <a href="https://forum.openrefine.org/c/dev">the Development section of our forum</a></li>
 </ul>
 <p><h1> Current &amp; Previous Contributors</h1></p>
 

--- a/documentation.md
+++ b/documentation.md
@@ -19,12 +19,12 @@ sidebar_link: true
 <ul>
   <li><a href="https://docs.openrefine.org/technical-reference/technical-reference-index">Information for developers</a></li>
   <li><a href="https://github.com/OpenRefine/OpenRefine/blob/master/CONTRIBUTING.md">Contributor guidelines</a></li>
-  <li><a href="https://groups.google.com/forum/?fromgroups#!forum/openrefine-dev">Developer discussion list</a></li>
+  <li><a href="https://forum.openrefine.org/c/dev">Developer discussion forum</a></li>
 </ul>
 
 <h2 id="support">Support</h2>
 <ul>
-  <li><a href="http://groups.google.com/group/openrefine/">OpenRefine support mailing list</a></li>
+  <li><a href="https://forum.openrefine.org/c/support">OpenRefine support forum</a></li>
   <li><a href="https://stackoverflow.com/questions/tagged/openrefine">StackOverflow tag</a></li>
   <li><a href="https://github.com/OpenRefine/OpenRefine/issues?milestone=&amp;page=1&amp;state=open">File a bug report or feature request</a></li>
 </ul>


### PR DESCRIPTION
As proposed on the mailing list, there is enthusiasm to migrate to Discourse for our mailing lists, so this PR changes the website to point to that.
