### PR TITLE
fix: improve button text contrast in dark mode (#503)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -188,5 +188,5 @@ code {
 /* Fix button text contrast in dark mode */
 html[data-theme="dark"] .button.button--primary,
 html[data-theme="dark"] .button.button--secondary {
-  color: var(--ifm-color-white);
+  color: var(--ifm-font-color-base);
 }


### PR DESCRIPTION
### Summary
Fixes an accessibility issue where primary button text appeared black in dark mode,
resulting in insufficient contrast against the blue background.

### Changes
- Ensure button text uses a light color in dark mode for better readability
- Align dark-mode button text contrast with light-mode behavior

### Screenshots

#### Before (Dark mode)
<img width="1885" height="705" alt="Screenshot 2026-01-04 121623" src="https://github.com/user-attachments/assets/d2f59c63-b0e7-45df-ba20-035ed23b8f5e" />

#### After (Dark mode)
<img width="1867" height="729" alt="Screenshot 2026-01-06 103824" src="https://github.com/user-attachments/assets/fee43838-3e07-4c1a-9eee-51f1c73ea659" />

### Result
- Improved visual clarity in dark mode
- Better contrast and readability
- Improved accessibility without changing button background colors

Fixes #503
